### PR TITLE
support short revisions for start and end parameter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ use least_satisfying::{least_satisfying, Satisfies};
 fn get_commits(start: &str, end: &str) -> Result<Vec<git::Commit>, Error> {
     eprintln!("fetching commits from {} to {}", start, end);
     let commits = git::get_commits_between(start, end)?;
-    assert_eq!(commits.first().expect("at least one commit").sha, start);
+    assert_eq!(commits.first().expect("at least one commit").sha, git::expand_commit(start)?);
 
     Ok(commits)
 }


### PR DESCRIPTION
resolves #20

```
cargo run -- --start 6a1c0637c --end 866a71325
    Finished dev [unoptimized + debuginfo] target(s) in 0.31s
     Running `target/debug/cargo-bisect-rustc --start 6a1c0637c --end 866a71325`
bisecting ci builds
starting at 6a1c0637c, ending at 866a71325
fetching commits from 6a1c0637c to 866a71325
opening existing repository at "rust.git"
refreshing repository
looking up first commit
looking up second commit
checking that commits are by bors and thus have ci artifacts...
finding bors merge commits
found 37 bors merge commits in the specified range
opening existing repository at "rust.git"
refreshing repository
no commits between 6a1c0637c and 866a71325 within last 167 days
```